### PR TITLE
set up CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Code owners
+/.github/CODEOWNERS @uklibraries/euk
+*       @uklibraries/euk


### PR DESCRIPTION
Set up CODEOWNERS file to define code owners who can approve PRs into "dev" branch.  In combination with ruleset [Require pull requests to prod](https://github.com/uklibraries/findingaid/settings/rules/9413891), this will limit users who can push code to the production branch and add in additional safeguards for internal developers.  Closes #13.