### PR TITLE
Fix build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,4 +10,3 @@ docker-compose.yml
 README.md
 LICENSE.txt
 public/cache
-pubic/js/app.js

--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,5 @@ dockerfile
 docker-compose.yml
 README.md
 LICENSE.txt
+public/cache
+pubic/js/app.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: docker compose logs
 
       - name: Run linting inside app container
-        run: docker compose run --rm -T findingaid /vendor/bin/phpcs -w --exclude=Generic.Files.LineLength --standard=PSR12 /tests /app
+        run: docker compose run --rm -T findingaid /opt/findingaid/vendor/bin/phpcs -w --exclude=Generic.Files.LineLength --standard=PSR12 /opt/findingaid/tests /opt/findingaid/app
 
       - name: Teardown
         if: always()
@@ -72,7 +72,7 @@ jobs:
         run: docker compose logs
 
       - name: Run tests inside app container
-        run: docker compose run --rm -T findingaid /vendor/bin/phpunit -c /phpunit.xml /tests
+        run: docker compose run --rm -T findingaid /opt/findingaid/vendor/bin/phpunit -c /opt/findingaid/phpunit.xml /opt/findingaid/tests
 
       - name: Teardown
         if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,8 +58,8 @@ RUN apk add --no-cache \
 WORKDIR /app
 
 COPY --from=jsmin /usr/bin/jsmin /usr/bin/jsmin
-COPY --from=development /vendor /vendor
-COPY ./phpunit.xml /phpunit.xml
+COPY --from=development /opt/findingaid/vendor /opt/findingaid/vendor
+COPY ./phpunit.xml /opt/findingaid/phpunit.xml
 COPY /app .
 
 COPY exe/build.sh /opt/findingaid/exe/build.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,14 +19,14 @@ RUN apk add --no-cache \
 COPY --from=composer:2.8 /usr/bin/composer /usr/bin/composer
 COPY --from=jsmin /usr/bin/jsmin /usr/bin/jsmin
 
-WORKDIR /
+WORKDIR /opt/findingaid
 
 COPY ./composer.json .
 COPY ./composer.lock .
 
 RUN composer install --no-interaction
 
-COPY exe/build.sh /exe/build.sh
+COPY /exe ./exe
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
@@ -49,10 +49,6 @@ COPY ./composer.lock .
 
 RUN composer install --no-interaction --no-dev
 
-WORKDIR /app
-
-COPY ./app .
-
 FROM php:8.3-fpm-alpine AS ci
 
 RUN apk add --no-cache \
@@ -62,11 +58,11 @@ RUN apk add --no-cache \
 WORKDIR /app
 
 COPY --from=jsmin /usr/bin/jsmin /usr/bin/jsmin
-COPY --from=prod-builder /app .
 COPY --from=development /vendor /vendor
 COPY ./phpunit.xml /phpunit.xml
+COPY /app .
 
-COPY exe/build.sh /exe/build.sh
+COPY exe/build.sh /opt/findingaid/exe/build.sh
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
@@ -76,14 +72,23 @@ CMD ["php-fpm", "-F"]
 
 FROM php:8.3-fpm-alpine AS production
 
-WORKDIR /app
+RUN apk add --no-cache \
+    libzip-dev \
+    bash
 
-COPY --from=prod-builder /app .
-COPY --from=prod-builder /composer/vendor /vendor
+COPY --from=jsmin /usr/bin/jsmin /usr/bin/jsmin
+COPY --from=prod-builder /composer/vendor /opt/findingaid/vendor
 
-COPY exe/build.sh /exe/build.sh
+WORKDIR /opt/findingaid
+
+COPY ./app ./app
+COPY ./public ./public
+COPY ./exe ./exe
+
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
+
+RUN ./exe/build.sh
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 EXPOSE 9000

--- a/docker-compose.ci.override.yml
+++ b/docker-compose.ci.override.yml
@@ -2,35 +2,6 @@ services:
   findingaid:
     build:
       context: .
-      target: CI
-    volumes:
-      - ./app:/app
-      - ./public:/public
-      - cache:/public/cache
-      - ./xml:/xml
-      - vendor:/vendor
-      - ./tests:/tests
-    networks:
-      - app_net
-
-  web:
-    image: nginx:1.29.0
-    ports:
-      - 8080:80
-    volumes:
-      - ./app:/app
-      - ./public:/public
-      - cache:/public/cache
-      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
-    networks:
-      - app_net
-    depends_on:
-      - findingaid
-
-networks:
-    app_net:
-        driver: bridge
-
-volumes:
-  vendor:
-  cache:
+      target: ci
+    environment:
+      APP_ENV: ci

--- a/docker-compose.dev.override.yml
+++ b/docker-compose.dev.override.yml
@@ -1,0 +1,11 @@
+services:
+  findingaid:
+    build:
+      target: development
+    environment:
+      APP_ENV: development
+    develop:
+      watch:
+        - action: restart
+          path: ./app/assets/js
+          target: /opt/findingaid/app/assets/js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,11 @@ services:
       - ./app:/opt/findingaid/app
       - ./public:/opt/findingaid/public
       - ./xml:/opt/findingaid/xml
-      - ./tests:/tests
+      - ./tests:/opt/findingaid/tests
+      - ./phpunit.xml:/opt/findingaid/phpunit.xml
     networks:
       - app_net
+
   web:
     image: nginx:1.29.0
     ports:
@@ -21,6 +23,7 @@ services:
       - app_net
     depends_on:
       - findingaid
+
 volumes:
   app:
   public:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,22 +4,26 @@ services:
       context: .
       target: development
     volumes:
-      - ./app:/app
-      - ./public:/public
-      - cache:/public/cache
-      - ./xml:/xml
-      - vendor:/vendor
+      - ./app:/opt/findingaid/app
+      - ./xml:/opt/findingaid/xml
+      - ./public:/opt/findingaid/public
     networks:
       - app_net
+    environment:
+      APP_ENV: development
+    develop:
+      watch:
+        - action: restart
+          path: ./app/assets/js
+          target: /opt/findingaid/app/assets/js
 
   web:
     image: nginx:1.29.0
     ports:
       - 8080:80
     volumes:
-      - ./app:/app
-      - ./public:/public
-      - cache:/public/cache
+      - ./app:/opt/findingaid/app
+      - ./public:/opt/findingaid/public
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
     networks:
       - app_net
@@ -29,7 +33,3 @@ services:
 networks:
     app_net:
         driver: bridge
-
-volumes:
-  vendor:
-  cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,21 +2,13 @@ services:
   findingaid:
     build:
       context: .
-      target: development
     volumes:
       - ./app:/opt/findingaid/app
-      - ./xml:/opt/findingaid/xml
       - ./public:/opt/findingaid/public
+      - ./xml:/opt/findingaid/xml
+      - ./tests:/tests
     networks:
       - app_net
-    environment:
-      APP_ENV: development
-    develop:
-      watch:
-        - action: restart
-          path: ./app/assets/js
-          target: /opt/findingaid/app/assets/js
-
   web:
     image: nginx:1.29.0
     ports:
@@ -29,6 +21,9 @@ services:
       - app_net
     depends_on:
       - findingaid
+volumes:
+  app:
+  public:
 
 networks:
     app_net:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -eu
-PUBLIC_DIR="/public"
+PUBLIC_DIR="/opt/findingaid/public"
 CACHE_DIR="$PUBLIC_DIR/cache"
 
 chmod 755 "$PUBLIC_DIR"
@@ -11,6 +11,10 @@ chown -R www-data:www-data "$CACHE_DIR"
 find "$CACHE_DIR" -type d -exec chmod 2775 "{}" \;
 find "$CACHE_DIR" -type f -exec chmod 0664 "{}" \;
 
-bash /exe/build.sh
+# APP_ENV set in compose file
+if [ "${APP_ENV:-}" = "development" ]; then
+    echo "Building js for dev"
+    bash /opt/findingaid/exe/build.sh
+fi
 
 exec "$@"

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -2,7 +2,7 @@ server {
     listen 80;
     server_name localhost;
 
-    root /public;
+    root /opt/findingaid/public;
     index index.php;
 
     location / {


### PR DESCRIPTION
Separated docker-compose files so that docker-compose.yml is now a base. Each stage should inherent values from the base that are overridden using compose's [merge feature](https://docs.docker.com/reference/compose-file/merge/). Examples below.
```sh
// For dev
docker compose -f docker-compose.yml -f docker-compose.dev.override.yml
// For ci
docker compose -f docker-compose.yml -f docker-compose.ci.override.yml
```