### PR TITLE
8 insufficient contrast on advance note

### DIFF
--- a/app/assets/css/extra.css
+++ b/app/assets/css/extra.css
@@ -128,25 +128,33 @@ label {
     background-color: #EFF4FD;
     border-left: 7px solid #1E8AFF;
     padding: 1rem;
-    display: flex;
     align-items: center;
-    
-    &h2 {
+    color:#000000
+}
+.in-page-alert h2 {
+        text-transform: uppercase;
+        font-size: 1.75rem;
+        font-weight: 900;
+        margin-top: 0;
+        color: #0033A0;
+        line-height: 1.2;
+}
+.in-page-alert h3 {
         text-transform: uppercase;
         font-size: 1.5rem;
-        font-weight: 900;
+        font-weight: 500;
+        margin-bottom: 5px;
+        margin-top: 10px;
         color: #0033A0;
-        margin: 0;
         line-height: 1.2;
-    }
-
-    &a {
+        
+}
+.in-page-alert a {
         color: #000000;
-        /*transition: color 0.3s ease-in-out, background-color 0.3s ease-in-out;*/
-    }
-    &a:hover {
+        transition: color 0.3s ease-in-out, background-color 0.3s ease-in-out;
+}
+.in-page-alert a:hover {
         color: #0033a0; 
-    }
 }
 
 /*.alert-warning a {

--- a/app/assets/css/extra.css
+++ b/app/assets/css/extra.css
@@ -1,5 +1,5 @@
-.fa-toc {
-}
+/**.fa-toc {
+}**/
 
 .fa-request.fa-requestable-toc {
     display: block;
@@ -10,8 +10,8 @@
     float: right;
 }
 
-.fa-request-summary {
-}
+/**.fa-request-summary {
+}**/
 
 .fa-request-summary-note {
     font-style: italic;
@@ -124,7 +124,15 @@ label {
 }
 
 .alert-warning {
-    color: #654f2a;
+    background-color: #EFF4FD;
+    border-left: 7px solid #1E8AFF;
+    border: none;
+    padding: 1rem;
+    color: #000000;
+}
+
+.alert-warning a {
+    color: #0033a0;
 }
 
 .alert-harmful {

--- a/app/assets/css/extra.css
+++ b/app/assets/css/extra.css
@@ -123,40 +123,6 @@ label {
     height: 80vh;
 }
 
-/* styling to match UK's in-page alert*/
-.in-page-alert {
-    background-color: #EFF4FD;
-    border-left: 7px solid #1E8AFF;
-    padding: 1rem;
-    align-items: center;
-    color:#000000
-}
-.in-page-alert h2 {
-        text-transform: uppercase;
-        font-size: 1.75rem;
-        font-weight: 900;
-        margin-top: 0;
-        color: #0033A0;
-        line-height: 1.2;
-}
-.in-page-alert h3 {
-        text-transform: uppercase;
-        font-size: 1.5rem;
-        font-weight: 500;
-        margin-bottom: 5px;
-        margin-top: 10px;
-        color: #0033A0;
-        line-height: 1.2;
-        
-}
-.in-page-alert a {
-        color: #000000;
-        transition: color 0.3s ease-in-out, background-color 0.3s ease-in-out;
-}
-.in-page-alert a:hover {
-        color: #0033a0; 
-}
-
 /*.alert-warning a {
     color: #000000;
 }
@@ -183,3 +149,62 @@ label {
 .green-alert-text {
     color: #246024;
 }
+
+/* Link styles */
+a {
+    color: #000000;
+}
+
+/* UK LIMESTONE STYLES */
+/* Styling to match Limestone's Underline Link */
+a.underline-link {
+    color:#000000;
+    background-attachment: scroll;
+    background-image: linear-gradient(to top,rgba(161,211,237,0.4) 0,rgba(161,211,237,0.4) 0.5em,transparent 0.5em,transparent 110%),linear-gradient(to top,rgba(0,51,160,0.4) 0,rgba(0,51,160,0.4) 2px,transparent 2px,transparent 100%);
+    background-repeat: no-repeat;
+    background-position: 0 0.5em, 0 0;
+    position: relative;
+    transition: 0.2s background-position ease-out;
+    font-weight: 300;
+    z-index: 1;
+    text-decoration: none;
+}
+
+a:hover.underline-link {
+    color:#0033A0;
+    background-position: 0 0, 1000px 2px;
+}
+
+/* styling to match central webcom's in-page alert*/
+.in-page-alert {
+    background-color: #EFF4FD;
+    border-left: 7px solid #1E8AFF;
+    padding: 1rem;
+    align-items: center;
+    color:#000000
+}
+.in-page-alert h2 {
+        text-transform: uppercase;
+        font-size: 1.75rem;
+        font-weight: 900;
+        margin-top: 0;
+        color: #0033A0;
+        line-height: 1.2;
+}
+.in-page-alert h3 {
+        text-transform: uppercase;
+        font-size: 1.5rem;
+        font-weight: 500;
+        margin-bottom: 5px;
+        margin-top: 10px;
+        color: #0033A0;
+        line-height: 1.2;
+        
+}
+/* .in-page-alert a {
+        color: #000000;
+        transition: color 0.3s ease-in-out, background-color 0.3s ease-in-out;
+}
+.in-page-alert a:hover {
+        color: #0033a0; 
+} */

--- a/app/assets/css/extra.css
+++ b/app/assets/css/extra.css
@@ -1,6 +1,3 @@
-/**.fa-toc {
-}**/
-
 .fa-request.fa-requestable-toc {
     display: block;
     margin: 0 auto;
@@ -9,9 +6,6 @@
 .fa-request.fa-requestable-contents {
     float: right;
 }
-
-/**.fa-request-summary {
-}**/
 
 .fa-request-summary-note {
     font-style: italic;
@@ -123,13 +117,6 @@ label {
     height: 80vh;
 }
 
-/*.alert-warning a {
-    color: #000000;
-}
-.alert-warning a:hover {
-    color: #1E8AFF;
-}*/
-
 .alert-harmful {
     background: #b1c9e8;
     color: #282828;
@@ -150,13 +137,8 @@ label {
     color: #246024;
 }
 
-/* Link styles */
-a {
-    color: #000000;
-}
-
 /* UK LIMESTONE STYLES */
-/* Styling to match Limestone's Underline Link */
+/* styling to match Limestone's Underline Link */
 a.underline-link {
     color:#000000;
     background-attachment: scroll;
@@ -201,10 +183,3 @@ a:hover.underline-link {
         line-height: 1.2;
         
 }
-/* .in-page-alert a {
-        color: #000000;
-        transition: color 0.3s ease-in-out, background-color 0.3s ease-in-out;
-}
-.in-page-alert a:hover {
-        color: #0033a0; 
-} */

--- a/app/assets/css/extra.css
+++ b/app/assets/css/extra.css
@@ -165,7 +165,7 @@ a.underline-link {
     background-position: 0 0.5em, 0 0;
     position: relative;
     transition: 0.2s background-position ease-out;
-    font-weight: 300;
+    font-weight: 400;
     z-index: 1;
     text-decoration: none;
 }

--- a/app/assets/css/extra.css
+++ b/app/assets/css/extra.css
@@ -129,11 +129,22 @@ label {
     border: none;
     padding: 1rem;
     color: #000000;
+
+    &a {
+        color: #000000;
+        /*transition: color 0.3s ease-in-out, background-color 0.3s ease-in-out;*/
+    }
+    &a:hover {
+        color: #0033a0; 
+    }
 }
 
-.alert-warning a {
-    color: #0033a0;
+/*.alert-warning a {
+    color: #000000;
 }
+.alert-warning a:hover {
+    color: #1E8AFF;
+}*/
 
 .alert-harmful {
     background: #b1c9e8;

--- a/app/assets/css/extra.css
+++ b/app/assets/css/extra.css
@@ -123,12 +123,22 @@ label {
     height: 80vh;
 }
 
-.alert-warning {
+/* styling to match UK's in-page alert*/
+.in-page-alert {
     background-color: #EFF4FD;
     border-left: 7px solid #1E8AFF;
-    border: none;
     padding: 1rem;
-    color: #000000;
+    display: flex;
+    align-items: center;
+    
+    &h2 {
+        text-transform: uppercase;
+        font-size: 1.5rem;
+        font-weight: 900;
+        color: #0033A0;
+        margin: 0;
+        line-height: 1.2;
+    }
 
     &a {
         color: #000000;

--- a/app/views/findingaid/advance_note.mustache
+++ b/app/views/findingaid/advance_note.mustache
@@ -1,25 +1,22 @@
 <div class="alert in-page-alert">
-    <h2>Visit the UK Libraries Special Collections Research Center</h2>
+    <h2>UK Libraries Special Collections Research Center</h2>
     <p><strong>Research Room Hours:</strong> Monday–Friday, 9:00 AM–4:00 PM. Appointments are recommended.</p>
-    <h3>Planning your visit</h3>
+    <h3>Plan your visit</h3>
     <p>There are two steps to prepare for your research visit:</p>
     
     <ol>
         <li>
-            <strong>Request materials</strong><br>
-            Request materials from this collection guide using your <a href="https://libguides.uky.edu/SCRCaccount">SCRC Researcher Account</a>.<br>
-            Please request items at least 5 business days in advance to ensure availability.  Most materials are stored off‑site.<br>
+            <strong>Request materials</strong> from this collection guide using your <a href="https://requests-libraries.uky.edu/">SCRC Researcher Account</a>.
         </li>
         <li>
-            <strong>Schedule your appointment</strong><br>
-            <a class="btn btn-primary" href="https://libguides.uky.edu/SCRCaccount/appointment" target="_blank" rel="noopener noreferrer">Schedule appointment</a>
+            <strong><a href="https://libguides.uky.edu/SCRCaccount/appointment">Schedule your appointment</a></strong>
         </li>
     </ol>
 
     <p>
-        Don't have an account? <a href="https://requests-libraries.uky.edu/">Register with your LinkBlue</a><br>
-        Non-UK user?  <a href="https://requests-libraries.uky.edu/aeonauth/aeon.dll?Action=10&Form=79">Create an account</a><br>
-        Need account help? View <a href="https://libguides.uky.edu/SCRCaccount">account set‑up and use instructions</a><br>
-        Questions? <a href="https://libraries.uky.edu/ContactSCRC">Contact SCRC</a>.
+        <!--Don't have an account? <a href="https://requests-libraries.uky.edu/">Register with your LinkBlue</a><br>
+        Non-UK user?  <a href="https://requests-libraries.uky.edu/aeonauth/aeon.dll?Action=10&Form=79">Create an account</a><br>-->
+        Need account help? <a href="https://libguides.uky.edu/SCRCaccount">View account set‑up and use instructions</a><br>
+        Questions? <a href="https://libraries.uky.edu/ContactSCRC">Contact SCRC</a>
     </p>
 </div>

--- a/app/views/findingaid/advance_note.mustache
+++ b/app/views/findingaid/advance_note.mustache
@@ -1,17 +1,25 @@
-<div class="alert alert-warning">
-<h2>Planning Your Research Visit</h2>
-<h3>Hours for Special Collections Research Center</h3>
-<p>Monday-Friday: 9am - 4pm. Appointments are recommended.</p>
-<p>
-<a class="btn btn-primary" href="https://libguides.uky.edu/SCRCaccount/appointment" target="_blank" rel="noopener noreferrer">Schedule appointment</a>
-</p>
+<div class="alert in-page-alert">
+    <h2>Visit the UK Libraries Special Collections Research Center</h2>
+    <p><strong>Research Room Hours:</strong> Monday–Friday, 9:00 AM–4:00 PM. Appointments are recommended.</p>
+    <h3>Planning your visit</h3>
+    <p>There are two steps to prepare for your research visit:</p>
+    
+    <ol>
+        <li>
+            <strong>Request materials</strong><br>
+            Request materials from this collection guide using your <a href="https://libguides.uky.edu/SCRCaccount">SCRC Researcher Account</a>.<br>
+            Please request items at least 5 business days in advance to ensure availability.  Most materials are stored off‑site.<br>
+        </li>
+        <li>
+            <strong>Schedule your appointment</strong><br>
+            <a class="btn btn-primary" href="https://libguides.uky.edu/SCRCaccount/appointment" target="_blank" rel="noopener noreferrer">Schedule appointment</a>
+        </li>
+    </ol>
 
-<p>
-Researchers must have an SCRC Researcher Account to request materials. View <a
-href="https://libguides.uky.edu/SCRCaccount" target="_blank" rel="noopener noreferrer">account set-up and use instructions here</a>.
-</p>
-
-<p>
-Questions? Contact SCRC via our <a href="https://libraries.uky.edu/ContactSCRC" target="_blank" rel="noopener noreferrer">Contact Form</a>.
-</p>
+    <p>
+        Don't have an account? <a href="https://requests-libraries.uky.edu/">Register with your LinkBlue</a><br>
+        Non-UK user?  <a href="https://requests-libraries.uky.edu/aeonauth/aeon.dll?Action=10&Form=79">Create an account</a><br>
+        Need account help? View <a href="https://libguides.uky.edu/SCRCaccount">account set‑up and use instructions</a><br>
+        Questions? <a href="https://libraries.uky.edu/ContactSCRC">Contact SCRC</a>.
+    </p>
 </div>

--- a/app/views/findingaid/advance_note.mustache
+++ b/app/views/findingaid/advance_note.mustache
@@ -1,22 +1,22 @@
 <div class="alert in-page-alert">
     <h2>UK Libraries Special Collections Research Center</h2>
-    <p><strong>Research Room Hours:</strong> Monday–Friday, 9:00 AM–4:00 PM. Appointments are recommended.</p>
+    <p><strong>Hours:</strong> Monday–Friday, 9:00 AM–4:00 PM. Appointments recommended.</p>
     <h3>Plan your visit</h3>
     <p>There are two steps to prepare for your research visit:</p>
     
     <ol>
         <li>
-            <strong>Request materials</strong> from this collection guide using your <a href="https://requests-libraries.uky.edu/">SCRC Researcher Account</a>.
+            <strong>Request materials</strong> from this collection guide using your <a class="underline-link" href="https://requests-libraries.uky.edu/">SCRC Researcher Account</a>.
         </li>
         <li>
-            <strong><a href="https://libguides.uky.edu/SCRCaccount/appointment">Schedule your appointment</a></strong>
+            <strong><a class="underline-link" href="https://libguides.uky.edu/SCRCaccount/appointment">Schedule your appointment</a></strong>
         </li>
     </ol>
 
     <p>
-        <!--Don't have an account? <a href="https://requests-libraries.uky.edu/">Register with your LinkBlue</a><br>
-        Non-UK user?  <a href="https://requests-libraries.uky.edu/aeonauth/aeon.dll?Action=10&Form=79">Create an account</a><br>-->
-        Need account help? <a href="https://libguides.uky.edu/SCRCaccount">View account set‑up and use instructions</a><br>
-        Questions? <a href="https://libraries.uky.edu/ContactSCRC">Contact SCRC</a>
+        <!--Don't have an account? <a class="underline-link" href="https://requests-libraries.uky.edu/">Register with your LinkBlue</a><br>
+        Non-UK user?  <a class="underline-link" href="https://requests-libraries.uky.edu/aeonauth/aeon.dll?Action=10&Form=79">Create an account</a><br>-->
+        Need account help? <a class="underline-link" href="https://libguides.uky.edu/SCRCaccount">View account set‑up and use instructions</a><br>
+        Questions? <a class="underline-link" href="https://libraries.uky.edu/ContactSCRC">Contact SCRC</a>
     </p>
 </div>

--- a/app/views/findingaid/advance_note.mustache
+++ b/app/views/findingaid/advance_note.mustache
@@ -1,6 +1,9 @@
 <div class="alert alert-warning">
+<h2>Planning Your Research Visit</h2>
+<h3>Hours for Special Collections Research Center</h3>
+<p>Monday-Friday: 9am - 4pm. Appointments are recommended.</p>
 <p>
-UK Libraries Special Collections Research Center is open <b>Monday to Friday, 9:00am to 4:00pm</b>. Appointments are encouraged but not required. <a href="https://libguides.uky.edu/SCRCaccount/appointment" target="_blank" rel="noopener noreferrer">Schedule an appointment here</a>.
+<a class="btn btn-primary" href="https://libguides.uky.edu/SCRCaccount/appointment" target="_blank" rel="noopener noreferrer">Schedule appointment</a>
 </p>
 
 <p>

--- a/app/views/findingaid/advance_note.mustache
+++ b/app/views/findingaid/advance_note.mustache
@@ -1,5 +1,5 @@
 <div class="alert alert-warning">
-<p class="green-alert-text">
+<p>
 UK Libraries Special Collections Research Center is open <b>Monday to Friday, 9:00am to 4:00pm</b>. Appointments are encouraged but not required. <a href="https://libguides.uky.edu/SCRCaccount/appointment" target="_blank" rel="noopener noreferrer">Schedule an appointment here</a>.
 </p>
 


### PR DESCRIPTION
Changes include:

- Advance Note component style to resemble [Limestone's In-page alert](https://web.uky.edu/training/paragraph-types/page-alert)
    - Fixed color contrast issue for WCAG 2.1 compliance on Advance Note
- Added an underline link style to resemble [Limestone's underline-link](https://patternlab.uky.edu/?p=atoms-link-underline)
    - Fixed links not being distinguishable from other content issue for WCAG 2.1 compliance on Advance Note
- Reworked the content and content layout of the advance note to provide better UX and clearer instructions on how to request materials based on the instructions found on [Libguides](https://libguides.uky.edu/SCRCaccount)
- Cleaned up extra.css file to remove unused or empty classes
- Updated look and feel to be closer to UK Brand Standards