### PR TITLE
Prod fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apk add --no-cache \
 
 COPY --from=composer:2.8 /usr/bin/composer /usr/bin/composer
 COPY --from=jsmin /usr/bin/jsmin /usr/bin/jsmin
+RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 
 WORKDIR /opt/findingaid
 
@@ -78,6 +79,7 @@ RUN apk add --no-cache \
 
 COPY --from=jsmin /usr/bin/jsmin /usr/bin/jsmin
 COPY --from=prod-builder /composer/vendor /opt/findingaid/vendor
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
 WORKDIR /opt/findingaid
 

--- a/app/controllers/findingaid.php
+++ b/app/controllers/findingaid.php
@@ -198,18 +198,7 @@ class Findingaid extends Controller
                                 }
                             }
                         }
-                        $prod_indicator = implode(DIRECTORY_SEPARATOR, [
-                            ROOT,
-                            'is_prod',
-                        ]);
-                        if (file_exists($prod_indicator)) {
-                            $url = 'https://exploreuk.uky.edu/?' .
-                                $search_field . '=' . urlencode($raw_search);
-                        } else {
-                            $url = 'https://uklibbackups.net/?' .
-                                $search_field . '=' . urlencode($raw_search);
-                        }
-
+                        $url = '/?' . $search_field . '=' . urlencode($raw_search);
                     }
                     else {
                         $data = $model->xpath("//{$link['field']}");
@@ -283,7 +272,7 @@ class Findingaid extends Controller
                         'collection_id' => $model->id(),
                         'call_number' => $model->unitid(),
                         'item_date' => $model->unitdate(),
-                        'item_url' => 'https://exploreuk.uky.edu/catalog/' . $model->id() . '/',
+                        'item_url' => '/catalog/' . $model->id() . '/',
                     ]
                 );
             }
@@ -391,7 +380,7 @@ class Findingaid extends Controller
             }
             else {
                 # This is probably a deleted ExploreUK finding aid
-                header("Location: https://exploreuk.uky.edu");
+                header("Location: /");
                 die();
             }
         }

--- a/app/models/component_model.php
+++ b/app/models/component_model.php
@@ -3,6 +3,9 @@ class ComponentModel extends Model
 {
     protected $subcomponents = [];
     private $basename;
+    public $config;
+    public $links;
+    public $xml;
 
     public function __construct(protected $id, private $component_id)
     {

--- a/app/models/findingaid_model.php
+++ b/app/models/findingaid_model.php
@@ -3,6 +3,7 @@ class FindingaidModel extends Model
 {
     public $path = null;
     public $exists = false;
+    public $metadata;
 
     public function __construct(protected $id)
     {


### PR DESCRIPTION
Three main fixes. 
1. Models were assigning variables to classes without declaring them first. PHP 8.2+ has deprecated this behavior. I declared each as public properties to address the issue.
2. Errors like the one in point 1 were printing in production. The php image we use provides some php.ini files with reasonable defaults for both production and dev. I include them in the correct stages in the Dockerfile.
3. Hardcoded paths were pushing users around to real production (https://exploreuk.uky.edu/) instead of our current "fake prod" (euk.ukpdp.org). Keeping with 12 factor, I made paths relative to the current server (whichever that may be).