### PR TITLE
#33, interactive headings need a button

### DIFF
--- a/app/assets/css/extra.css
+++ b/app/assets/css/extra.css
@@ -78,15 +78,15 @@ label {
    background-color: #ffffff !important;
 }
 
-.panel-heading[data-toggle="collapse"] .panel-title:after {
+.accordion-trigger .glyphicon {
     font-family: "Glyphicons Halflings";
     color: #666;
     float: right;
-    content: "\e114";
+    transition: transform 0.2s;
 }
 
-.panel-heading[data-toggle="collapse"].collapsed .panel-title:after {
-    content: "\e080";
+.accordion-trigger:not(.collapsed) .glyphicon {
+    transform: rotate(90deg);
 }
 
 .panel-title a {
@@ -181,5 +181,18 @@ a:hover.underline-link {
         margin-top: 10px;
         color: #0033A0;
         line-height: 1.2;
-        
+}
+
+.panel-heading {
+    padding: 0px;
+}
+
+.accordion-trigger {
+    display: block;
+    background-color: transparent;
+    height: 100%;
+    width: 100%;
+    border: none;
+    padding: 10px 15px;
+    text-align: left;
 }

--- a/app/assets/css/extra.css
+++ b/app/assets/css/extra.css
@@ -79,7 +79,6 @@ label {
 }
 
 .accordion-trigger .glyphicon {
-    font-family: "Glyphicons Halflings";
     color: #666;
     float: right;
     transition: transform 0.2s;

--- a/app/views/findingaid/component.mustache
+++ b/app/views/findingaid/component.mustache
@@ -1,7 +1,5 @@
 <div class="panel panel-default" id="{{heading_id}}">
-  <div class="panel-heading" {{#collapsible}}data-toggle="collapse" data-target="#{{body_id}}" aria-expanded="true"{{/collapsible}}>
-      <h4 class="panel-title">{{{label}}}</h4>
-  </div>
+  {{> panel_heading }}
   <div class="panel-body{{#collapsible}} collapse in{{/collapsible}}" id="{{body_id}}">
     <ul class="list-unstyled">
     {{#container_lists}}

--- a/app/views/findingaid/panel.mustache
+++ b/app/views/findingaid/panel.mustache
@@ -1,7 +1,5 @@
 <div class="panel panel-default" id="{{heading_id}}">
-  <div class="panel-heading" {{#collapsible}}data-toggle="collapse" data-target="#{{body_id}}" aria-expanded="true"{{/collapsible}}>
-      <h4 class="panel-title">{{label}}</h4>
-  </div>
+  {{> panel_heading }}
   <div class="panel-body{{#collapsible}} collapse in{{/collapsible}}" id="{{body_id}}">
     {{single-field}}
     {{#multi-field}}

--- a/app/views/findingaid/panel_heading.mustache
+++ b/app/views/findingaid/panel_heading.mustache
@@ -3,7 +3,7 @@
   {{#collapsible}}
   <button class="accordion-trigger" type="button" data-toggle="collapse" data-target="#{{body_id}}" aria-expanded="true">
     {{{label}}}
-    <span {{#collapsible}}class="glyphicon glyphicon-chevron-right pull-right" aria-hidden="true"{{/collapsible}}></span>
+    <span class="glyphicon glyphicon-chevron-right pull-right" aria-hidden="true"></span>
   </button>
   {{/collapsible}}
   {{^collapsible}}

--- a/app/views/findingaid/panel_heading.mustache
+++ b/app/views/findingaid/panel_heading.mustache
@@ -1,7 +1,7 @@
 <div class="panel-heading">
   <h4 class="panel-title">
   {{#collapsible}}
-  <button class="accordion-trigger" type="button" data-toggle="collapse" data-target="#{{body_id}}" aria-expanded="true">
+  <button class="accordion-trigger" type="button" data-toggle="collapse" data-target="#{{body_id}}" aria-controls="{{body_id}}" aria-expanded="true">
     {{{label}}}
     <span class="glyphicon glyphicon-chevron-right pull-right" aria-hidden="true"></span>
   </button>

--- a/app/views/findingaid/panel_heading.mustache
+++ b/app/views/findingaid/panel_heading.mustache
@@ -11,4 +11,3 @@
   {{/collapsible}}
   </h4>
 </div>
-

--- a/app/views/findingaid/panel_heading.mustache
+++ b/app/views/findingaid/panel_heading.mustache
@@ -1,0 +1,14 @@
+<div class="panel-heading">
+  <h4 class="panel-title">
+  {{#collapsible}}
+  <button class="accordion-trigger" type="button" data-toggle="collapse" data-target="#{{body_id}}" aria-expanded="true">
+    {{{label}}}
+    <span {{#collapsible}}class="glyphicon glyphicon-chevron-right pull-right" aria-hidden="true"{{/collapsible}}></span>
+  </button>
+  {{/collapsible}}
+  {{^collapsible}}
+  <span class="accordion-trigger">{{{label}}}</span>
+  {{/collapsible}}
+  </h4>
+</div>
+

--- a/app/views/findingaid/requests.mustache
+++ b/app/views/findingaid/requests.mustache
@@ -1,9 +1,7 @@
 <div class="col-md-6 fa-request-summary fa-long">
   {{> advance_note}}
   <div class="panel panel-default" id="{{id}}">
-    <div class="panel-heading">
-      <h4 class="panel-title">{{label}}</h4>
-    </div>
+    {{> panel_heading }}
     <div class="panel-body">
       <h4 class="fa-request-summary-note fa-request-hidden">
         No items have been requested.

--- a/app/views/findingaid/toc.mustache
+++ b/app/views/findingaid/toc.mustache
@@ -3,9 +3,7 @@
   {{> advance_note}}
   {{/requestable}}
   <div class="panel panel-default" id="{{id}}">
-    <div class="panel-heading">
-      <h4 class="panel-title">{{label}}</h4>
-    </div>
+  {{> panel_heading }}
     <div class="panel-body">
       <ul class="list-unstyled">
         {{#entries}}

--- a/app/views/findingaid/toc.mustache
+++ b/app/views/findingaid/toc.mustache
@@ -3,7 +3,7 @@
   {{> advance_note}}
   {{/requestable}}
   <div class="panel panel-default" id="{{id}}">
-  {{> panel_heading }}
+    {{> panel_heading }}
     <div class="panel-body">
       <ul class="list-unstyled">
         {{#entries}}


### PR DESCRIPTION
Addresses #33 by wrapping `<h4>`'s in a button/span element with proper aria controls. New component panel_heading is smart enough to know when it is part of a collapsible section and will render as either a button or span as appropriate. Changed the arrow from a CSS after property to be part of the HTML.