### PR TITLE
update copyright statement and license; update contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,8 @@
+# Contributors
+
+## Special thanks for all the people who had helped this project so far:
+
+* [Sarah Dorpinghaus](https://github.com/sarahdorpinghaus)
+* [Neal Powers](https://github.com/Nealium104)
+* [Nicole Sand](https://github.com/nrsa222)
+* [MLE Slone](https://github.com/cokernel)

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2023 MLE Slone
+Copyright (c) 2016-2026 University of Kentucky
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -75,10 +75,13 @@ detects and can repair many PSR-12 violations. Developers can use `make lint` to
 get a report of linting violations, and `make lint-fix` to fix those that can be
 automatically fixed. These deliberately exclude line length as a fix.
 
+## Contributors
+Sarah Dorpinghaus, Neal Powers, Nicole Sand, and MLE Slone. For details, consult [CONTRIBUTORS](CONTRIBUTORS.md).
+
 ## Copyright
 
-This program is Copyright (C) 2016-2024 MLE Slone. For
-details, consult LICENSE.txt.
+This program is Copyright (C) 2016-2026 University of Kentucky. For
+details, consult [LICENSE](LICENSE.txt).
 
 This program uses the following libraries:
 
@@ -90,3 +93,4 @@ This program uses the following libraries:
 - [Bootstrap](https://getbootstrap.com)
 - [jQuery](https://jquery.org)
 - [jQuery UI](https://jqueryui.com)
+


### PR DESCRIPTION
- Fix copyright statement and license to comply with University of Kentucky's [AR7:6](https://regs.uky.edu/sites/default/files/2022-03/ar7-6.pdf).
- Acknowledge contributors

Closes #45.