### PR TITLE
add resolver to prevent DNS crashes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - app_net
     depends_on:
       - findingaid
+    restart: unless-stopped
 
 volumes:
   app:

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -5,6 +5,8 @@ server {
     root /opt/findingaid/public;
     index index.php;
 
+    resolver 127.0.0.11 valid=5s;
+
     location / {
         try_files $uri $uri/ /index.php?$query_string;
     }
@@ -12,7 +14,8 @@ server {
     location ~ \.php$ {
         try_files $uri =404;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass findingaid:9000;
+        set $upstream_findingaid findingaid:9000;
+        fastcgi_pass $upstream_findingaid;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param PATH_INFO $fastcgi_path_info;
         include fastcgi_params;


### PR DESCRIPTION
Uses a resolver to fix DNS crashing on web container startup. Adds a restart policy to the default file.

Fixes #48.